### PR TITLE
Handled case of String

### DIFF
--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -2,14 +2,22 @@ module Unmarshal
 
 # package code goes here
 
-export unmarshal # returns a reconstrcuted variable from a JSON parsed string
+export unmarshal # returns a reconstructed variable from a JSON parsed string
 """
 Called with a given DataType and using the dictionary output of a JSON.parse , it will try to reconstruct the DataType from the JSON dictionary.
 
+    unmarshal(T, dict)
+
     unmarshal(typeof(var), JSON.parse(JSON.json(var)) == var
 """
-function unmarshal{T}(DT :: Type{Array{T}}, parsedJson)
-    #    @show "unmarshalArrayComposite"
+
+function unmarshal(DT :: DataType, parsedJson :: String) 
+#    @show "direct conversion from string"
+	DT(parsedJson)
+end
+
+function unmarshal{T}(DT :: Type{Array{T}}, parsedJson :: Array)
+#        @show "unmarshalArrayComposite"
 
     tmp = DT(length(parsedJson))
     for cnt=1:length(parsedJson)
@@ -19,12 +27,12 @@ function unmarshal{T}(DT :: Type{Array{T}}, parsedJson)
 end
 
 
-function unmarshal{T <: Number}(DT :: Type{Array{T}}, parsedJson)
+function unmarshal{T <: Number}(DT :: Type{Array{T}}, parsedJson :: Array)
 #    @show "unmarshalArrayNumber"
     map(T, parsedJson)
 end
 
-function unmarshal{T <: Number}(DT :: Type{Array{Complex{T}}}, parsedJson)
+function unmarshal{T <: Number}(DT :: Type{Array{Complex{T}}}, parsedJson :: Array)
 #        @show "unmarshalArrayComplex"
     tmp = DT(length(parsedJson))
     for cnt=1:length(parsedJson)
@@ -34,7 +42,7 @@ function unmarshal{T <: Number}(DT :: Type{Array{Complex{T}}}, parsedJson)
 end
 
 
-function unmarshal{T}(DT :: Type{Array{T, 2}}, parsedJson)
+function unmarshal{T}(DT :: Type{Array{T, 2}}, parsedJson :: Array)
 #    @show "unmarshalArray2"
 
     sizes = (length(parsedJson[1]), length(parsedJson) )
@@ -47,7 +55,7 @@ function unmarshal{T}(DT :: Type{Array{T, 2}}, parsedJson)
 end
 
 
-function unmarshal{T, N}(DT :: Type{Array{T, N}}, parsedJson)
+function unmarshal{T, N}(DT :: Type{Array{T, N}}, parsedJson :: Array)
 #    @show "unmarshalArrayN"
     if N == 1
         # This gets called if type was defined as Array{T,1}, instead of Array{T}
@@ -71,7 +79,7 @@ function unmarshal{T, N}(DT :: Type{Array{T, N}}, parsedJson)
 end
 
 
-function unmarshal(DT, parsedJson)
+function unmarshal(DT :: DataType, parsedJson :: Associative)
 #    @show "unmarshalStruct"
 
     tup = ()

--- a/test/unmarshal.jl
+++ b/test/unmarshal.jl
@@ -25,9 +25,9 @@ immutable Qux
 end
 
 
-@test Unmarshal.unmarshal(Foo, JSON.parse(input)) == Foo(Bar(17))
-@test Unmarshal.unmarshal(Baz, JSON.parse(input)) == Baz(Nullable(3.14), Bar(17))
-@test Unmarshal.unmarshal(Qux, JSON.parse(input)) == Qux(Nullable{String}(),Bar(17))
+@test Unmarshal.unmarshal(Foo, JSON.parse(input)) === Foo(Bar(17))
+@test Unmarshal.unmarshal(Baz, JSON.parse(input)) === Baz(Nullable(3.14), Bar(17))
+@test Unmarshal.unmarshal(Qux, JSON.parse(input)) === Qux(Nullable{String}(),Bar(17))
 @test_throws ErrorException Unmarshal.unmarshal(Bar, JSON.parse(input)) 
 
 #Test for structures of handling 1-D arrays
@@ -101,4 +101,4 @@ higher = higherlayer(val)
 jstring = JSON.json(higher)
 @test_throws ErrorException Unmarshal.unmarshal(higherlayer, JSON.parse(jstring))
 
-
+@test Unmarshal.unmarshal(String, JSON.parse(json("Test"))) == "Test"


### PR DESCRIPTION
Added case where you call JSON.parse on a string directly, in which
case the JSON library returns a string object directly instead of
dictionary.