### PR TITLE
Make Unmarshal compatible with fields of type Union{Missing,T}

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,4 @@
 julia 0.6
 JSON
+Missings
+Nullables

--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -8,7 +8,7 @@ function prettyPrint(verboseLvl, str)
     for cntr=1:verboseLvl
         tabs = tabs * "\t"
     end
-    println("$(tabs)$(str)")    
+    println("$(tabs)$(str)")
 end
 
 
@@ -35,12 +35,12 @@ true
 ```
 
 """
-function unmarshal(DT :: Type, parsedJson :: String, verbose :: Bool = false, verboseLvl :: Int = 0) 
+function unmarshal(DT :: Type, parsedJson :: String, verbose :: Bool = false, verboseLvl :: Int = 0)
     if (verbose)
         prettyPrint(verboseLvl, "$(DT) (String)")
         verboseLvl+=1
     end
-	DT(parsedJson)
+    DT(parsedJson)
 end
 
 function unmarshal(::Type{Vector{E}}, parsedJson::Vector, verbose :: Bool = false, verboseLvl :: Int = 0) where E
@@ -77,7 +77,7 @@ function unmarshal(DT :: Type, parsedJson :: Associative, verbose :: Bool = fals
     tup = ()
     for iter in fieldnames(DT)
         DTNext = fieldtype(DT,iter)
-#        @show iter, DTNext, !haskey(parsedJson, string(iter)) 
+#        @show iter, DTNext, !haskey(parsedJson, string(iter))
 
         if !haskey(parsedJson, string(iter)) 
             try
@@ -91,7 +91,7 @@ function unmarshal(DT :: Type, parsedJson :: Associative, verbose :: Bool = fals
         else
             val = unmarshal( DTNext, parsedJson[string(iter)], verbose, verboseLvl)
         end
-            
+
         tup = (tup..., val)
     end
 
@@ -103,7 +103,7 @@ function unmarshal(DT :: Type{T}, parsedJson :: Array{Any,N}, verbose :: Bool = 
         prettyPrint(verboseLvl, "$(T) $(N) Dimensions, length $(length(parsedJson))")
         verboseLvl += 1
     end
-    
+
     ((unmarshal(fieldtype(T,1), field, verbose, verboseLvl) for field in parsedJson)...,)
 end
 
@@ -119,7 +119,7 @@ function unmarshal(DT :: Type{T}, parsedJson :: Associative, verbose :: Bool = f
     val
 end
 
-unmarshal(::Type{T}, x::Number, verbose :: Bool = false, verboseLvl :: Int = 0) where T<:Number = T(x) 
+unmarshal(::Type{T}, x::Number, verbose :: Bool = false, verboseLvl :: Int = 0) where T<:Number = T(x)
 unmarshal(::Type{Nullable{T}}, x, verbose :: Bool = false, verboseLvl :: Int = 0) where T = Nullable(unmarshal(T, x))
 unmarshal(::Type{Nullable{T}}, x::Void, verbose :: Bool = false, verboseLvl :: Int = 0) where T = Nullable{T}()
 

--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -15,26 +15,6 @@ end
 export unmarshal # returns a reconstructed variable from a JSON parsed string
 
 using JSON
-"""
-
-unmarshal(T, dict, verbose = false)
-
-Reconstructs an object of Type T using the dictionary output of a JSON.parse.
-
-Set verbose `true` to get debug information about how the data hierarchy is unmarshalled. This might be useful to track down parsing errors and/or mismatches between the JSON object and the Type definition.
-
-#Example
-
-```jldoctest
-julia> using JSON
-
-julia> var = randn(Float64, 5);  # Should work for most other variations of types you can think of
-
-julia> unmarshal(typeof(var), JSON.parse(JSON.json(var)) ) == var
-true
-```
-
-"""
 function unmarshal(DT :: Type, parsedJson :: String, verbose :: Bool = false, verboseLvl :: Int = 0)
     if (verbose)
         prettyPrint(verboseLvl, "$(DT) (String)")
@@ -64,6 +44,25 @@ function unmarshal(::Type{Array{E, N}}, parsedJson::Vector, verbose :: Bool = fa
 end
 
 
+"""
+    unmarshal(T, dict[, verbose[, verboselvl]])
+
+Reconstructs an object of Type T using the dictionary output of a `JSON.parse.`
+
+Set verbose `true` to get debug information about how the data hierarchy is unmarshalled. This might be useful to track down parsing errors and/or mismatches between the JSON object and the Type definition.
+
+# Example
+
+```jldoctest
+julia> using JSON
+
+julia> var = randn(Float64, 5);  # Should work for most other variations of types you can think of
+
+julia> unmarshal(typeof(var), JSON.parse(JSON.json(var)) ) == var
+true
+```
+
+"""
 function unmarshal(DT :: Type, parsedJson :: Associative, verbose :: Bool = false, verboseLvl :: Int = 0)
     if (verbose)
             prettyPrint(verboseLvl, "$(DT) Associative")

--- a/test/unmarshal.jl
+++ b/test/unmarshal.jl
@@ -1,5 +1,7 @@
 using Unmarshal
 using JSON
+import Missings: Missing, missing
+
 using Base.Test
 import Base.==
 
@@ -22,12 +24,14 @@ end
 immutable Qux
     baz::Nullable{String}
     bar::Bar
+    foo::Union{Missing,Float64}
+    missingfield::Union{Missing,String}
 end
 
 
 @test Unmarshal.unmarshal(Foo, JSON.parse(input)) === Foo(Bar(17))
 @test Unmarshal.unmarshal(Baz, JSON.parse(input)) === Baz(Nullable(3.14), Bar(17))
-@test Unmarshal.unmarshal(Qux, JSON.parse(input)) === Qux(Nullable{String}(),Bar(17))
+@test Unmarshal.unmarshal(Qux, JSON.parse(input)) === Qux(Nullable{String}(),Bar(17),3.14,missing)
 @test_throws ArgumentError Unmarshal.unmarshal(Bar, JSON.parse(input))
 
 #Test for structures of handling 1-D arrays

--- a/test/unmarshal.jl
+++ b/test/unmarshal.jl
@@ -28,7 +28,7 @@ end
 @test Unmarshal.unmarshal(Foo, JSON.parse(input)) === Foo(Bar(17))
 @test Unmarshal.unmarshal(Baz, JSON.parse(input)) === Baz(Nullable(3.14), Bar(17))
 @test Unmarshal.unmarshal(Qux, JSON.parse(input)) === Qux(Nullable{String}(),Bar(17))
-@test_throws ArgumentError Unmarshal.unmarshal(Bar, JSON.parse(input)) 
+@test_throws ArgumentError Unmarshal.unmarshal(Bar, JSON.parse(input))
 
 #Test for structures of handling 1-D arrays
 type StructOfArrays
@@ -154,6 +154,4 @@ dictTest = DictTest(Dict{Int, String}(1 => "Test1", 2 => "Test2"))
 #@show JSON.json(dictTest)
 #@show JSON.parse(JSON.json(dictTest))
 @test Unmarshal.unmarshal(DictTest, JSON.parse(JSON.json(dictTest)),true) == dictTest
-
-
 


### PR DESCRIPTION
Since Nullable is being moved out of base in 0.7 and performance of small Unions has been improved, many packages are using Union{Missing,T} to represent missing data rather than Nullable{T}. This PR supports both paradigms.