### PR TITLE
Unmarshalling of Arrays with a single entity

### DIFF
--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -48,7 +48,7 @@ function unmarshal{E}(::Type{Vector{E}}, parsedJson::Vector, verbose :: Bool = f
         verboseLvl+=1
     end
 
-    E[unmarshal(E, x, verbose, verboseLvl) for x in parsedJson]
+    [(unmarshal(E, field, verbose, verboseLvl) for field in parsedJson)...]
 end
 
 unmarshal{E}(::Type{Array{E}}, xs::Vector, verbose :: Bool = false, verboseLvl :: Int = 0) = unmarshal(Vector{E}, xs, verbose, verboseLvl)
@@ -95,6 +95,15 @@ function unmarshal(DT :: Type, parsedJson :: Associative, verbose :: Bool = fals
     end
 
     DT(tup...)
+end
+
+function unmarshal{T<:Tuple, N}(DT :: Type{T}, parsedJson :: Array{Any,N}, verbose :: Bool = false, verboseLvl :: Int = 0)
+    if (verbose)
+        prettyPrint(verboseLvl, "$(T) $(N) Dimensions, length $(length(parsedJson))")
+        verboseLvl += 1
+    end
+    
+    ((unmarshal(fieldtype(T,1), field, verbose, verboseLvl) for field in parsedJson)...)
 end
 
 unmarshal{T<:Number}(::Type{T}, x::Number, verbose :: Bool = false, verboseLvl :: Int = 0) = T(x)

--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -147,7 +147,7 @@ unmarshal(::Type{T}, x::Number, verbose :: Bool = false, verboseLvl :: Int = 0) 
 unmarshal(::Type{Nullable{T}}, x, verbose :: Bool = false, verboseLvl :: Int = 0) where T = Nullable(unmarshal(T, x))
 unmarshal(::Type{Nullable{T}}, x::Void, verbose :: Bool = false, verboseLvl :: Int = 0) where T = Nullable{T}()
 
-#unmarshal(T::Type, x, verbose :: Bool = false, verboseLvl :: Int = 0) =
-#    throw(ArgumentError("no unmarshal function defined to convert $(typeof(x)) to $(T); consider providing a specialization"))
+unmarshal(T::Type, x, verbose :: Bool = false, verboseLvl :: Int = 0) =
+    throw(ArgumentError("no unmarshal function defined to convert $(typeof(x)) to $(T); consider providing a specialization"))
 
 end # module

--- a/test/unmarshal.jl
+++ b/test/unmarshal.jl
@@ -127,3 +127,4 @@ jstring = JSON.json(testTuples)
 @test Unmarshal.unmarshal(Tuple{Array{Float64}}, JSON.parse(jstring)) == (([testElement...] for testElement in testTuples)...)
 @test Unmarshal.unmarshal(Array{Tuple{Float64}}, JSON.parse(jstring)) == [testTuples...]
 @test Unmarshal.unmarshal(Array{Array{Float64}}, JSON.parse(jstring)) == [([testElement...] for testElement in testTuples)...]
+@test Unmarshal.unmarshal(Tuple{Tuple{Float64}}, JSON.parse(jstring), true) == testTuples

--- a/test/unmarshal.jl
+++ b/test/unmarshal.jl
@@ -120,4 +120,10 @@ jstring = JSON.json(tmp3)
 
 @test_throws ArgumentError unmarshal(Nullable{Int64}, ones(Float64, 1))
 
-
+# Test handling of Tuples
+testTuples = ((1.0, 2.0, 3.0, 4.0), (2.0, 3.0))
+jstring = JSON.json(testTuples)
+@test Unmarshal.unmarshal(Tuple{Tuple{Float64}}, JSON.parse(jstring)) == testTuples
+@test Unmarshal.unmarshal(Tuple{Array{Float64}}, JSON.parse(jstring)) == (([testElement...] for testElement in testTuples)...)
+@test Unmarshal.unmarshal(Array{Tuple{Float64}}, JSON.parse(jstring)) == [testTuples...]
+@test Unmarshal.unmarshal(Array{Array{Float64}}, JSON.parse(jstring)) == [([testElement...] for testElement in testTuples)...]


### PR DESCRIPTION
Sometimes, you want the base struct to have an array of elements that may only need a single element. If the JSON file then has the single element without the array brackets, [], the file should still be loadable.