### PR TITLE
Fix #34 for Julia 1.0.

### DIFF
--- a/src/Unmarshal.jl
+++ b/src/Unmarshal.jl
@@ -112,7 +112,7 @@ function unmarshal(DT :: Type, parsedJson :: AbstractDict, verbose :: Bool = fal
            prettyPrint(verboseLvl-1, "\\--> $(iter) <: $(DTNext) ")
         end
 
-        if !haskey(parsedJson, string(iter)) || isnothing(parsedJson[string(iter)])
+        if !haskey(parsedJson, string(iter)) || parsedJson[string(iter)] === nothing
             # check whether DTNext is compatible with any scheme for missing values
             val = if DTNext <: Nullable
                 DTNext()


### PR DESCRIPTION
The recent PR #34 started using the `isnothing` function which is not available in Julia `1.0`. Thus, the build currently fails for 1.0.
This PR avoids the helper by using the `=== nothing` syntax.

Alternatively, one could bump the minimum required Julia version to `1.1` which introduced `isnothing` but I don't see a reason to drop LTS `1.0` support for such a small thing.